### PR TITLE
Warning fix

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -22,7 +22,7 @@ end
 
 desc "Run the test suite"
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = "-f documentation"
+  t.rspec_opts = "-f documentation -w"
 end
 
 task :default => :spec

--- a/spec/facade_spec.rb
+++ b/spec/facade_spec.rb
@@ -8,11 +8,13 @@ require 'rspec'
 require 'facade'
 
 RSpec.describe Facade do
-  let(:facade) do
-    module FooModule
+  before(:all) do
+    FooModule = Module.new do
       def testme(str); str; end
-    end
+    end unless defined?(FooModule)
+  end
 
+  let(:facade) do
     Class.new(String) do |klass|
       klass.extend Facade
       facade File, :basename, 'dirname'


### PR DESCRIPTION
Update the specs slightly to avoid a redefinition warning, and add the "-w" option to the spec task.